### PR TITLE
Removed \n after code blocks so that no extra empty line will be printed...

### DIFF
--- a/markdown-extra.php
+++ b/markdown-extra.php
@@ -1030,7 +1030,7 @@ class Markdown_Parser {
 		# trim leading newlines and trailing newlines
 		$codeblock = preg_replace('/\A\n+|\n+\z/', '', $codeblock);
 
-		$codeblock = "<pre><code>$codeblock\n</code></pre>";
+		$codeblock = "<pre><code>$codeblock</code></pre>";
 		return "\n\n".$this->hashBlock($codeblock)."\n\n";
 	}
 


### PR DESCRIPTION
Today I was using WP-Markdown with Crayon Syntax Highlighter. I found that there will be always a blank line after my code blocks. So I did this simple small hack and it worked in my case :-)
