### PR TITLE
Fix breaks in responsive layouts

### DIFF
--- a/css/markdown-editor.css
+++ b/css/markdown-editor.css
@@ -1,5 +1,5 @@
 /* MarkDown editor */
-.wmd-panel{min-width: 500px;width: 100%;}
+.wmd-panel{width: 100%;}
 .wmd-button-bar {width: 100%;}
 .wmd-preview {border: 2px dotted #CCCCCC;clear: both;color: #555555;font-size: 14px !important;line-height: 1.4em !important;margin-bottom: 5px;margin-right: 5px;padding: 3px;width: 100%;}
 .wmd-preview pre{background:none;border:none;}


### PR DESCRIPTION
Using min-width breaks responsive layouts.

Here's an example of what the default Twenty twelve theme looks like before the fix on a mobile:
https://dl.dropboxusercontent.com/u/2758854/2013-09-30%2019.57.33.png

The only downside of this fix is that the help button gets a little squished on mobile.

Hiding the undo/redo buttons on mobile with a media query would fix it permanently. Do you want me to send a PR for this?
